### PR TITLE
WPH 276

### DIFF
--- a/Source/Catrobat/Catrobat.Core/Utilities/Helpers/VariableHelper.cs
+++ b/Source/Catrobat/Catrobat.Core/Utilities/Helpers/VariableHelper.cs
@@ -2,6 +2,7 @@
 using System.Collections.ObjectModel;
 using System.Linq;
 using Catrobat.IDE.Core.Models;
+using Catrobat.IDE.Core.Models.Bricks;
 
 namespace Catrobat.IDE.Core.Utilities.Helpers
 {
@@ -20,11 +21,41 @@ namespace Catrobat.IDE.Core.Utilities.Helpers
 
         public static void DeleteGlobalVariable(Program project, GlobalVariable variable)
         {
+            foreach (var currentSprite in project.Sprites)
+            {
+
+                foreach (var currentScript in currentSprite.Scripts)
+                {
+
+                    foreach (var currentBrick in currentScript.Bricks)
+                    {
+                        if (currentBrick is SetVariableBrick || currentBrick is ChangeVariableBrick)
+                        {
+                            ((VariableBrick)currentBrick).Variable = null;
+                        }
+
+                    }
+                }
+            }
+
             project.GlobalVariables.Remove(variable);
         }
 
         public static void DeleteLocalVariable(Program project, Sprite sprite, LocalVariable variable)
         {
+            foreach (var currentScript in sprite.Scripts)
+            {
+
+                foreach (var currentBrick in currentScript.Bricks)
+                {
+                    if (currentBrick is SetVariableBrick || currentBrick is ChangeVariableBrick)
+                    {
+                        ((VariableBrick)currentBrick).Variable = null;
+                    }
+
+                }
+            }
+
             sprite.LocalVariables.Remove(variable);
         }
 

--- a/Source/Catrobat/Catrobat.Core/Utilities/Helpers/VariableHelper.cs
+++ b/Source/Catrobat/Catrobat.Core/Utilities/Helpers/VariableHelper.cs
@@ -38,6 +38,23 @@ namespace Catrobat.IDE.Core.Utilities.Helpers
                 }
             }
 
+            if(project.Background.Count >= 1)
+            {
+                var currentSprite = project.Background[0];
+                foreach (var currentScript in currentSprite.Scripts)
+                {
+
+                    foreach (var currentBrick in currentScript.Bricks)
+                    {
+                        if (currentBrick is SetVariableBrick || currentBrick is ChangeVariableBrick)
+                        {
+                            ((VariableBrick)currentBrick).Variable = null;
+                        }
+
+                    }
+                }
+            }
+                
             project.GlobalVariables.Remove(variable);
         }
 
@@ -53,6 +70,23 @@ namespace Catrobat.IDE.Core.Utilities.Helpers
                         ((VariableBrick)currentBrick).Variable = null;
                     }
 
+                }
+            }
+
+            if (project.Background.Count >= 1)
+            {
+                var currentSprite = project.Background[0];
+                foreach (var currentScript in currentSprite.Scripts)
+                {
+
+                    foreach (var currentBrick in currentScript.Bricks)
+                    {
+                        if (currentBrick is SetVariableBrick || currentBrick is ChangeVariableBrick)
+                        {
+                            ((VariableBrick)currentBrick).Variable = null;
+                        }
+
+                    }
                 }
             }
 

--- a/Source/Catrobat/Catrobat.Core/ViewModels/Editor/Formula/VariableSelectionViewModel.cs
+++ b/Source/Catrobat/Catrobat.Core/ViewModels/Editor/Formula/VariableSelectionViewModel.cs
@@ -5,6 +5,8 @@ using Catrobat.IDE.Core.UI;
 using Catrobat.IDE.Core.Utilities.Helpers;
 using GalaSoft.MvvmLight.Command;
 using GalaSoft.MvvmLight.Messaging;
+using System.Diagnostics;
+using Catrobat.IDE.Core.Models.Bricks;
 
 namespace Catrobat.IDE.Core.ViewModels.Editor.Formula
 {

--- a/Source/Catrobat/Catrobat.XML_Test/Catrobat.XML_Test.csproj
+++ b/Source/Catrobat/Catrobat.XML_Test/Catrobat.XML_Test.csproj
@@ -104,6 +104,10 @@
       <Project>{54144ca7-b859-4f79-b682-dad92b4e3353}</Project>
       <Name>Catrobat.Player.WindowsPhone</Name>
     </ProjectReference>
+    <ProjectReference Include="..\Catrobat.Core\Catrobat.Core.csproj">
+      <Project>{E2E83DD3-7C09-4AAE-B8F6-357C0DA2317E}</Project>
+      <Name>Catrobat.Core</Name>
+    </ProjectReference>
     <ProjectReference Include="..\Catrobat.Xml\Catrobat.Xml.csproj">
       <Project>{5a97f09e-beb2-48ee-bec2-bedea5a4145d}</Project>
       <Name>Catrobat.Xml</Name>

--- a/Source/Catrobat/Catrobat.XML_Test/VariableBrickTests.cs
+++ b/Source/Catrobat/Catrobat.XML_Test/VariableBrickTests.cs
@@ -20,44 +20,67 @@ namespace Catrobat.XML_Test
             var testprog = new Program();
 
             Sprite testsprite = new Sprite();
+            Sprite backgroundsprite = new Sprite();
             testprog.Sprites.Add(testsprite);
+            testprog.Background.Add(backgroundsprite);
 
             var varbrick = new SetVariableBrick();
             var chnbrick = new ChangeVariableBrick();
+            var varbrickbg = new SetVariableBrick();
+            var chnbrickbg = new ChangeVariableBrick();
             var startscript = new StartScript();
+            var startscriptbg = new StartScript();
 
             startscript.Bricks.Add(varbrick);
             startscript.Bricks.Add(chnbrick);
+            startscriptbg.Bricks.Add(varbrickbg);
+            startscriptbg.Bricks.Add(chnbrickbg);
             testprog.Sprites[0].Scripts.Add(startscript);
+            testprog.Background[0].Scripts.Add(startscriptbg);
 
             var newGlobalVariable = new GlobalVariable { Name = "GlobalTestVariable" };
             testprog.GlobalVariables.Add(newGlobalVariable);
             varbrick.Variable = newGlobalVariable;
             chnbrick.Variable = newGlobalVariable;
+            varbrickbg.Variable = newGlobalVariable;
+            chnbrickbg.Variable = newGlobalVariable;
 
             Assert.AreNotEqual(varbrick.Variable, null);
             Assert.AreNotEqual(chnbrick.Variable, null);
+            Assert.AreNotEqual(varbrickbg.Variable, null);
+            Assert.AreNotEqual(chnbrickbg.Variable, null);
             Assert.AreNotEqual(testprog.GlobalVariables.Count, 0);
 
             VariableHelper.DeleteGlobalVariable(testprog, newGlobalVariable);
 
             Assert.AreEqual(varbrick.Variable, null);
             Assert.AreEqual(chnbrick.Variable, null);
+            Assert.AreEqual(varbrickbg.Variable, null);
+            Assert.AreEqual(chnbrickbg.Variable, null);
             Assert.AreEqual(testprog.GlobalVariables.Count, 0);
 
             var newLocalVariable = new LocalVariable { Name = "LocalTestVariable" };
+            var newLocalVariablebg = new LocalVariable { Name = "LocalTestVariablebg" };
             testsprite.LocalVariables.Add(newLocalVariable);
             varbrick.Variable = newLocalVariable;
             chnbrick.Variable = newLocalVariable;
+            varbrickbg.Variable = newLocalVariable;
+            chnbrickbg.Variable = newLocalVariable;
+
 
             Assert.AreNotEqual(varbrick.Variable, null);
             Assert.AreNotEqual(chnbrick.Variable, null);
+            Assert.AreNotEqual(varbrickbg.Variable, null);
+            Assert.AreNotEqual(chnbrickbg.Variable, null);
             Assert.AreNotEqual(testsprite.LocalVariables.Count, 0);
 
             VariableHelper.DeleteLocalVariable(testprog, testsprite, newLocalVariable);
+            VariableHelper.DeleteLocalVariable(testprog, backgroundsprite, newLocalVariable);
 
             Assert.AreEqual(varbrick.Variable, null);
             Assert.AreEqual(chnbrick.Variable, null);
+            Assert.AreEqual(varbrickbg.Variable, null);
+            Assert.AreEqual(chnbrickbg.Variable, null);
             Assert.AreEqual(testsprite.LocalVariables.Count, 0);
         }
 

--- a/Source/Catrobat/Catrobat.XML_Test/VariableBrickTests.cs
+++ b/Source/Catrobat/Catrobat.XML_Test/VariableBrickTests.cs
@@ -3,12 +3,64 @@ using System.Xml.Linq;
 using Catrobat.IDE.Core.Xml.XmlObjects.Bricks.Variables;
 using Catrobat.IDE.Core.Xml.XmlObjects.Formulas;
 using Microsoft.VisualStudio.TestPlatform.UnitTestFramework;
+using Catrobat.IDE.Core.Models;
+using Catrobat.IDE.Core.Models.Bricks;
+using Catrobat.IDE.Core.Models.Scripts;
+using Catrobat.IDE.Core.Utilities.Helpers;
 
 namespace Catrobat.XML_Test
 {
     [TestClass]
     public class VariableBrickTests
     {
+
+        [TestMethod]
+        public void AssignedVariablesShouldBeNullAfterDeletingVariables()
+        {
+            var testprog = new Program();
+
+            Sprite testsprite = new Sprite();
+            testprog.Sprites.Add(testsprite);
+
+            var varbrick = new SetVariableBrick();
+            var chnbrick = new ChangeVariableBrick();
+            var startscript = new StartScript();
+
+            startscript.Bricks.Add(varbrick);
+            startscript.Bricks.Add(chnbrick);
+            testprog.Sprites[0].Scripts.Add(startscript);
+
+            var newGlobalVariable = new GlobalVariable { Name = "GlobalTestVariable" };
+            testprog.GlobalVariables.Add(newGlobalVariable);
+            varbrick.Variable = newGlobalVariable;
+            chnbrick.Variable = newGlobalVariable;
+
+            Assert.AreNotEqual(varbrick.Variable, null);
+            Assert.AreNotEqual(chnbrick.Variable, null);
+            Assert.AreNotEqual(testprog.GlobalVariables.Count, 0);
+
+            VariableHelper.DeleteGlobalVariable(testprog, newGlobalVariable);
+
+            Assert.AreEqual(varbrick.Variable, null);
+            Assert.AreEqual(chnbrick.Variable, null);
+            Assert.AreEqual(testprog.GlobalVariables.Count, 0);
+
+            var newLocalVariable = new LocalVariable { Name = "LocalTestVariable" };
+            testsprite.LocalVariables.Add(newLocalVariable);
+            varbrick.Variable = newLocalVariable;
+            chnbrick.Variable = newLocalVariable;
+
+            Assert.AreNotEqual(varbrick.Variable, null);
+            Assert.AreNotEqual(chnbrick.Variable, null);
+            Assert.AreNotEqual(testsprite.LocalVariables.Count, 0);
+
+            VariableHelper.DeleteLocalVariable(testprog, testsprite, newLocalVariable);
+
+            Assert.AreEqual(varbrick.Variable, null);
+            Assert.AreEqual(chnbrick.Variable, null);
+            Assert.AreEqual(testsprite.LocalVariables.Count, 0);
+        }
+
         [TestMethod]
         public void ChangeVariableBrickHasToAllowNullReferenceOfUserVariableAsInitialBrick()
         {


### PR DESCRIPTION
Variables that are deleted but are also assign to bricks will now be completely removed from the project resulting in having the "NEW" again in the UI where the assigned variable was.
For Global and Local. Also added a test to check this